### PR TITLE
Add simple web frontend to interact with API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,11 @@ python api.py
 
 The server will listen on `http://0.0.0.0:8000` by default. FastAPI automatically provides interactive documentation at `/docs`.
 
+### Web frontend
+
+This repository includes a small static frontend located in `frontend/`. When the
+API server is running you can open `http://localhost:8000/` in your browser to
+interact with prompts. The interface supports creating new prompts, viewing all
+stored prompts, voting, commenting and regenerating prompts via the API.
+
 Make sure to set the `OPENAI_API_KEY` environment variable if you plan to use the `regenerate` endpoint.

--- a/api.py
+++ b/api.py
@@ -1,4 +1,6 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from typing import Optional
 
@@ -6,6 +8,14 @@ from prompter import PromptManager
 
 app = FastAPI(title="Prompter API")
 pm = PromptManager()
+
+# Serve the simple frontend
+app.mount("/static", StaticFiles(directory="frontend"), name="static")
+
+
+@app.get("/")
+def read_index():
+    return FileResponse("frontend/index.html")
 
 class PromptCreate(BaseModel):
     text: str

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prompter Frontend</title>
+    <style>
+        body { font-family: Arial, sans-serif; max-width: 800px; margin: auto; }
+        .prompt { border: 1px solid #ccc; padding: 10px; margin: 10px 0; }
+        .iterations { background: #f9f9f9; padding: 5px; }
+        .comments { background: #eef; padding: 5px; }
+        button { margin-right: 5px; }
+    </style>
+</head>
+<body>
+    <h1>Prompter</h1>
+
+    <h2>Create Prompt</h2>
+    <textarea id="newPrompt" rows="3" cols="80" placeholder="Enter prompt text..."></textarea><br>
+    <button onclick="createPrompt()">Create</button>
+
+    <h2>Prompts</h2>
+    <div id="prompts"></div>
+
+<script>
+const apiBase = '';
+
+function fetchPrompts() {
+    fetch(apiBase + '/prompts')
+        .then(r => r.json())
+        .then(data => {
+            const container = document.getElementById('prompts');
+            container.innerHTML = '';
+            data.forEach(p => {
+                const div = document.createElement('div');
+                div.className = 'prompt';
+                div.innerHTML = renderPrompt(p);
+                container.appendChild(div);
+            });
+        });
+}
+
+function renderPrompt(p) {
+    const last = p.iterations[p.iterations.length-1].text;
+    let html = `<b>ID:</b> ${p.id}<br>`;
+    html += `<b>Created:</b> ${p.created_at}<br>`;
+    html += `<b>Latest:</b> ${escapeHtml(last)}<br>`;
+    html += `<b>👍:</b> ${p.thumbs_up} <b>👎:</b> ${p.thumbs_down}<br>`;
+    html += `<button onclick="ratePrompt('${p.id}', true)">👍</button>`;
+    html += `<button onclick="ratePrompt('${p.id}', false)">👎</button>`;
+    html += `<button onclick="showIterations('${p.id}')">Show Iterations</button>`;
+    html += `<button onclick="showCommentBox('${p.id}')">Add Comment</button>`;
+    html += `<button onclick="regeneratePrompt('${p.id}')">Regenerate</button>`;
+    html += `<div id="iter-${p.id}" class="iterations" style="display:none"></div>`;
+    html += `<div id="comment-${p.id}" style="display:none">
+                <textarea id="comment-text-${p.id}" rows="2" cols="60" placeholder="Enter comment..."></textarea>
+                <button onclick="submitComment('${p.id}')">Submit</button>
+             </div>`;
+    html += `<div class="comments">${p.comments.map(c => `<div>${escapeHtml(c.text)}</div>`).join('')}</div>`;
+    return html;
+}
+
+function escapeHtml(text) {
+    const div = document.createElement('div');
+    div.innerText = text;
+    return div.innerHTML;
+}
+
+function createPrompt() {
+    const text = document.getElementById('newPrompt').value;
+    fetch(apiBase + '/prompts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+    }).then(() => {
+        document.getElementById('newPrompt').value = '';
+        fetchPrompts();
+    });
+}
+
+function ratePrompt(id, up) {
+    fetch(apiBase + `/prompts/${id}/rate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ up })
+    }).then(fetchPrompts);
+}
+
+function showIterations(id) {
+    const div = document.getElementById('iter-' + id);
+    if (div.style.display === 'none') {
+        fetch(apiBase + `/prompts/${id}`)
+            .then(r => r.json())
+            .then(data => {
+                div.innerHTML = data.iterations.map(it => `<div>${escapeHtml(it.text)}</div>`).join('');
+                div.style.display = 'block';
+            });
+    } else {
+        div.style.display = 'none';
+    }
+}
+
+function showCommentBox(id) {
+    const div = document.getElementById('comment-' + id);
+    div.style.display = div.style.display === 'none' ? 'block' : 'none';
+}
+
+function submitComment(id) {
+    const text = document.getElementById('comment-text-' + id).value;
+    fetch(apiBase + `/prompts/${id}/comment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+    }).then(() => {
+        document.getElementById('comment-text-' + id).value = '';
+        fetchPrompts();
+    });
+}
+
+function regeneratePrompt(id) {
+    const systemPrompt = prompt('System prompt (optional):');
+    fetch(apiBase + `/prompts/${id}/regenerate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ system_prompt: systemPrompt || null })
+    })
+    .then(r => r.json())
+    .then(data => {
+        alert('New iteration:\n' + data.text);
+        fetchPrompts();
+    });
+}
+
+fetchPrompts();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an HTML/JS frontend implementing prompt listing, creation, voting, commenting and regeneration
- serve the frontend through FastAPI
- document how to use the new frontend

## Testing
- `python -m py_compile api.py prompter.py`
- `pip install fastapi uvicorn`
- `pip install openai`
- `python api.py` *(fails unless `OPENAI_API_KEY` is set)*
- `OPENAI_API_KEY=dummykey python api.py`

------
https://chatgpt.com/codex/tasks/task_e_68580632396c8324b8d1a0daf9fcd52a