### PR TITLE
Add editable system prompt

### DIFF
--- a/api.py
+++ b/api.py
@@ -29,6 +29,9 @@ class Comment(BaseModel):
 class RegenerateRequest(BaseModel):
     system_prompt: Optional[str] = None
 
+class SystemPrompt(BaseModel):
+    text: str
+
 @app.get("/prompts")
 def list_prompts():
     return pm.list_prompts()
@@ -64,6 +67,15 @@ def regenerate_prompt(prompt_id: str, req: RegenerateRequest):
     except KeyError:
         raise HTTPException(status_code=404, detail="Prompt not found")
     return {"text": new_text}
+
+@app.get("/system_prompt")
+def get_system_prompt():
+    return {"system_prompt": pm.get_system_prompt()}
+
+@app.post("/system_prompt")
+def set_system_prompt(sp: SystemPrompt):
+    pm.set_system_prompt(sp.text)
+    return {"success": True}
 
 if __name__ == "__main__":
     import uvicorn

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,6 +15,10 @@
 <body>
     <h1>Prompter</h1>
 
+    <h2>System Prompt</h2>
+    <textarea id="systemPrompt" rows="3" cols="80" placeholder="System prompt..."></textarea><br>
+    <button onclick="saveSystemPrompt()">Save</button>
+
     <h2>Create Prompt</h2>
     <textarea id="newPrompt" rows="3" cols="80" placeholder="Enter prompt text..."></textarea><br>
     <button onclick="createPrompt()">Create</button>
@@ -64,6 +68,23 @@ function escapeHtml(text) {
     const div = document.createElement('div');
     div.innerText = text;
     return div.innerHTML;
+}
+
+function fetchSystemPrompt() {
+    fetch(apiBase + '/system_prompt')
+        .then(r => r.json())
+        .then(data => {
+            document.getElementById('systemPrompt').value = data.system_prompt || '';
+        });
+}
+
+function saveSystemPrompt() {
+    const text = document.getElementById('systemPrompt').value;
+    fetch(apiBase + '/system_prompt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text })
+    });
 }
 
 function createPrompt() {
@@ -131,6 +152,7 @@ function regeneratePrompt(id) {
     });
 }
 
+fetchSystemPrompt();
 fetchPrompts();
 </script>
 </body>

--- a/prompter.py
+++ b/prompter.py
@@ -25,15 +25,25 @@ class PromptManager:
     def _ensure_db(self):
         if not os.path.exists(self.db_path):
             with open(self.db_path, 'w') as f:
-                json.dump({"prompts": []}, f, indent=4)
+                json.dump({"prompts": [], "system_prompt": ""}, f, indent=4)
 
     def _load(self):
         with open(self.db_path, 'r') as f:
             self.db = json.load(f)
+        if "system_prompt" not in self.db:
+            self.db["system_prompt"] = ""
+            self._save()
 
     def _save(self):
         with open(self.db_path, 'w') as f:
             json.dump(self.db, f, indent=4)
+
+    def get_system_prompt(self) -> str:
+        return self.db.get("system_prompt", "")
+
+    def set_system_prompt(self, text: str):
+        self.db["system_prompt"] = text
+        self._save()
 
     def create_prompt(self, text: str) -> str:
         entry = {
@@ -79,6 +89,9 @@ class PromptManager:
             if p["id"] == prompt_id:
                 last = p["iterations"][-1]["text"]
                 messages = []
+                stored_system = self.get_system_prompt()
+                if stored_system:
+                    messages.append({"role": "system", "content": stored_system})
                 if system_prompt:
                     messages.append({"role": "system", "content": system_prompt})
                 messages.append({"role": "user", "content": last})

--- a/prompts_db.json
+++ b/prompts_db.json
@@ -23,5 +23,6 @@
            "thumbs_down": 0,
            "comments": []
        }
-   ]
+   ],
+   "system_prompt": ""
 }


### PR DESCRIPTION
## Summary
- persist a global `system_prompt` in `PromptManager`
- expose API endpoints to read/update the system prompt
- show and edit the system prompt in the frontend
- send the stored system prompt with all OpenAI requests

## Testing
- `python -m py_compile api.py prompter.py`

------
https://chatgpt.com/codex/tasks/task_e_68580bebcc348324afd87e0c1011a578