### PR TITLE
Add script to generate KQL queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project provides a simple prompt management system with an optional API for
 Install dependencies:
 
 ```bash
-pip install fastapi uvicorn
+pip install fastapi uvicorn openai
 ```
 
 ## Running the API
@@ -25,11 +25,16 @@ The server will listen on `http://0.0.0.0:8000` by default. FastAPI automaticall
 
 ### Web frontend
 
-This repository includes a small static frontend located in `frontend/`. When the
-API server is running you can open `http://localhost:8000/` in your browser to
-interact with prompts. The interface sports a playful neobrutalist design that
-makes browsing prompt history and jumping back into previous prompts easy. You
-can create new prompts, view stored prompts, vote, comment and regenerate
-responses via the API.
+This repository includes a small static frontend located in `frontend/`. When the API server is running you can open `http://localhost:8000/` in your browser to interact with prompts. The interface sports a playful neobrutalist design that makes browsing prompt history and jumping back into previous prompts easy. You can create new prompts, view stored prompts, vote, comment and regenerate responses via the API.
 
 Make sure to set the `OPENAI_API_KEY` environment variable if you plan to use the `regenerate` endpoint.
+
+## Generating KQL queries
+
+A helper script `generate_kql.py` has been added to turn natural language requests into Kusto Query Language queries. Provide the question on the command line and the script will output the KQL query produced by OpenAI:
+
+```bash
+python generate_kql.py "Find all IPs related to a specific user's sign ins"
+```
+
+The script stores the question in the prompt history and then calls the OpenAI API with a system prompt instructing the model to respond only with KQL. Ensure that `OPENAI_API_KEY` is set before running the script.

--- a/generate_kql.py
+++ b/generate_kql.py
@@ -1,0 +1,25 @@
+import sys
+from prompter import PromptManager
+
+DEFAULT_KQL_SYSTEM_PROMPT = (
+    "You are an assistant that generates Kusto Query Language (KQL) queries. "
+    "Given a natural language description of a question about security or log data, "
+    "respond only with the corresponding KQL query."
+)
+
+
+def generate_kql(question: str) -> str:
+    pm = PromptManager()
+    # Store the user's question as a prompt and generate a KQL query
+    pid = pm.create_prompt(question)
+    return pm.regenerate(pid, system_prompt=DEFAULT_KQL_SYSTEM_PROMPT)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python generate_kql.py 'your question'")
+        sys.exit(1)
+
+    question = " ".join(sys.argv[1:])
+    query = generate_kql(question)
+    print(query)

--- a/prompter.py
+++ b/prompter.py
@@ -17,21 +17,25 @@ openai.api_key = env_key
 DB_PATH = "prompts_db.json"
 
 class PromptManager:
-    def __init__(self, db_path: str = DB_PATH):
+    def __init__(self, db_path: str = DB_PATH, default_system_prompt: str = ""):
         self.db_path = db_path
+        self.default_system_prompt = default_system_prompt
         self._ensure_db()
         self._load()
 
     def _ensure_db(self):
         if not os.path.exists(self.db_path):
             with open(self.db_path, 'w') as f:
-                json.dump({"prompts": [], "system_prompt": ""}, f, indent=4)
+                json.dump({"prompts": [], "system_prompt": self.default_system_prompt}, f, indent=4)
 
     def _load(self):
         with open(self.db_path, 'r') as f:
             self.db = json.load(f)
         if "system_prompt" not in self.db:
-            self.db["system_prompt"] = ""
+            self.db["system_prompt"] = self.default_system_prompt
+            self._save()
+        elif self.default_system_prompt and not self.db.get("system_prompt"):
+            self.db["system_prompt"] = self.default_system_prompt
             self._save()
 
     def _save(self):


### PR DESCRIPTION
## Summary
- add `generate_kql.py` helper script to produce KQL queries using OpenAI
- allow `PromptManager` to provide a default system prompt
- document how to generate KQL queries with the new script

## Testing
- `python -m py_compile generate_kql.py prompter.py`
- `OPENAI_API_KEY=fake python generate_kql.py "Find all IPs related to a specific user's sign ins"` *(fails: invalid API key)*

------
https://chatgpt.com/codex/tasks/task_e_6858164cf39483249d7067c0b0209ed0